### PR TITLE
Improving currency checks

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -194,12 +194,11 @@ defmodule Money do
 
   @spec new(String.t | integer | t, atom) :: t
   def new(int, currency) when is_integer(int) do
-    cond do
-      currency_exist?(currency) ->
-        %Money{amount: int, currency: currency}
-    end
+    check_currency(currency)
+    %Money{amount: int, currency: currency}
   end
   def new(bitstr, currency) when is_bitstring(bitstr) do
+    check_currency(currency)
     case Integer.parse(bitstr) do
       :error -> raise ArgumentError
       {x, _} -> %Money{amount: x, currency: currency}
@@ -355,5 +354,9 @@ defmodule Money do
   defp reverse_group(str, count, list) do
     {first, last} = String.split_at(str, -count)
     reverse_group(first, count, [last | list])
+  end
+
+  defp check_currency(currency) do
+    if !Map.has_key?(@currencies, currency), do: raise ArgumentError, "currency #{currency} doesn’t exist"
   end
 end

--- a/lib/money.ex
+++ b/lib/money.ex
@@ -192,13 +192,13 @@ defmodule Money do
     end
   end)
 
-  @spec new(String.t | integer | t, atom) :: t
+  @spec new(String.t | integer | t, atom | String.t) :: t
   def new(int, currency) when is_integer(int) do
-    check_currency(currency)
+    currency = convert_currency(currency)
     %Money{amount: int, currency: currency}
   end
   def new(bitstr, currency) when is_bitstring(bitstr) do
-    check_currency(currency)
+    currency = convert_currency(currency)
     case Integer.parse(bitstr) do
       :error -> raise ArgumentError
       {x, _} -> %Money{amount: x, currency: currency}
@@ -356,7 +356,10 @@ defmodule Money do
     reverse_group(first, count, [last | list])
   end
 
-  defp check_currency(currency) do
+  defp convert_currency(currency) when is_binary(currency),
+    do: currency |> String.upcase |> String.to_existing_atom |> convert_currency
+  defp convert_currency(currency) do
     if !Map.has_key?(@currencies, currency), do: raise ArgumentError, "currency #{currency} doesn’t exist"
+    currency
   end
 end

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -3,6 +3,12 @@ defmodule MoneyTest do
 
 	require Money
 
+  test "new/2 requires existing currency" do
+    assert_raise ArgumentError, fn ->
+      Money.new(123, :ABC)
+    end
+  end
+
 	test "test factory USD" do
 		assert Money.new(123, :USD) == Money.usd(123)
 	end
@@ -13,12 +19,6 @@ defmodule MoneyTest do
 
 	test "test factory with string" do
 		assert Money.new("+124", :EUR) == Money.eur(124)
-	end
-
-	test "test factory non esistent Currency" do
-		assert_raise CondClauseError, fn ->
-		    Money.new(124, :paradise) == nil
-		end
 	end
 
 	test "conversion error" do

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -21,6 +21,11 @@ defmodule MoneyTest do
 		assert Money.new("+124", :EUR) == Money.eur(124)
 	end
 
+  test "use string currency key" do
+    assert Money.new(1000, "USD") == Money.usd(1000)
+    assert Money.new(1000, "usd") == Money.usd(1000)
+  end
+
 	test "conversion error" do
 		assert_raise FunctionClauseError, fn ->
 		  Money.new(:atom, :USD)


### PR DESCRIPTION
Moved the `cond` to a currency check method that became a currency conversion method which allows for strings as currency symbols.
`Money.new(1000_00, "USD")` or `Money.new(1000_00, "usd")`