### PR TITLE
Add Ecto type support

### DIFF
--- a/lib/money/ecto_type.ex
+++ b/lib/money/ecto_type.ex
@@ -1,0 +1,51 @@
+if Code.ensure_compiled?(Ecto.Type) do
+  defmodule Money.Ecto.Type do
+    @moduledoc """
+    Provides a type for Ecto usage.
+    The underlying data type should be an integer.
+
+    This type expects you to use a single currency.
+    The currency must be defined in your configuration.
+
+        config :money,
+          default_currency: :GBP
+
+    ## Migration Example
+
+        create table(:my_table) do
+          add :amount, :integer
+        end
+
+    ## Schema Example
+
+        schema "my_table" do
+          field :amount, Money.Ecto.Type
+        end
+    """
+
+    @behaviour Ecto.Type
+
+    @spec type :: :integer
+    def type, do: :integer
+
+    @spec cast(String.t | integer) :: {:ok, Money.t}
+    def cast(val)
+    def cast(str) when is_binary(str) do
+      value = str |> String.replace(",", "") |> String.replace(~r/.*?([\d]+(?:\.\d+)?)/, "\\1")
+      case Float.parse(value) do
+        {float, _} -> {:ok, Money.new(Kernel.round(float * 100))}
+        :error -> :error
+      end
+    end
+    def cast(int) when is_integer(int), do: {:ok, Money.new(int)}
+    def cast(_), do: :error
+
+    @spec load(integer) :: {:ok, Money.t}
+    def load(int) when is_integer(int), do: {:ok, Money.new(int)}
+
+    @spec dump(integer | Money.t) :: {:ok, :integer}
+    def dump(int) when is_integer(int), do: {:ok, int}
+    def dump(%Money{} = m), do: {:ok, m.amount}
+    def dump(_), do: :error
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,9 @@ defmodule Money.Mixfile do
 
   defp deps do
     [
+      # Soft dependencies
+      {:ecto, "~> 1.0 or ~> 2.0", optional: true},
+
       # Code style
       {:credo, "~> 0.4-beta", only: [:dev, :test]},
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "credo": {:hex, :credo, "0.4.0-beta2", "28d0a7c19fdc4460a3b4f1f1ef48a687378452bd242a704a719623fc7993ed56", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}
+  "ecto": {:hex, :ecto, "1.1.7", "c37127248756e725eb8254b371764b40c05a90c104b2065d1d4f7e32573fdbec", [:mix], [{:sbroker, "~> 0.7", [hex: :sbroker, optional: true]}, {:postgrex, "~> 0.11.0", [hex: :postgrex, optional: true]}, {:poolboy, "~> 1.4", [hex: :poolboy, optional: false]}, {:poison, "~> 1.0 or ~> 2.0", [hex: :poison, optional: true]}, {:mariaex, "~> 0.5.0 or ~> 0.6.0", [hex: :mariaex, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/test/money/ecto_type_test.exs
+++ b/test/money/ecto_type_test.exs
@@ -1,0 +1,56 @@
+if Code.ensure_compiled?(Ecto.Type) do
+  defmodule Money.Ecto.TypeTest do
+    use ExUnit.Case, async: true
+    doctest Money.Ecto.Type
+
+    alias Money.Ecto.Type
+
+    setup do
+      Application.put_env(:money, :default_currency, :GBP)
+
+      on_exit fn ->
+        Application.delete_env(:money, :default_currency)
+      end
+    end
+
+    test "type/0" do
+      assert Type.type == :integer
+    end
+
+    test "cast/1 String" do
+      assert Type.cast("1000") == {:ok, Money.new(100000, :GBP)}
+      assert Type.cast("1234.56") == {:ok, Money.new(123456, :GBP)}
+      assert Type.cast("1,234.56") == {:ok, Money.new(123456, :GBP)}
+      assert Type.cast("£1234.56") == {:ok, Money.new(123456, :GBP)}
+      assert Type.cast("£1,234.56") == {:ok, Money.new(123456, :GBP)}
+      assert Type.cast("£ 1234.56") == {:ok, Money.new(123456, :GBP)}
+      assert Type.cast("£ 1,234.56") == {:ok, Money.new(123456, :GBP)}
+      assert Type.cast("£ 1234") == {:ok, Money.new(123400, :GBP)}
+      assert Type.cast("£ 1,234") == {:ok, Money.new(123400, :GBP)}
+    end
+
+    test "cast/1 integer" do
+      assert Type.cast(1000) == {:ok, Money.new(1000, :GBP)}
+    end
+
+    test "cast/1 other" do
+      assert Type.cast([]) == :error
+    end
+
+    test "load/1 integer" do
+      assert Type.load(1000) == {:ok, Money.new(1000, :GBP)}
+    end
+
+    test "dump/1 integer" do
+      assert Type.dump(1000) == {:ok, 1000}
+    end
+
+    test "dmmp/1 Money" do
+      assert Type.dump(Money.new(1000, :GBP)) == {:ok, 1000}
+    end
+
+    test "dump/1 other" do
+      assert Type.dump([]) == :error
+    end
+  end
+end


### PR DESCRIPTION
Adds support for the `Ecto.Type` behaviour (#12) without requiring Ecto as a dependency.
If a project doesn’t have Ecto, the `Money.Ecto.Type` module will be ignored.