### PR TITLE
Add options for Money.to_string

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -235,7 +235,7 @@ defmodule Money do
     do: Money.new(div(amount, divisor), cur)
   def divide(a, b), do: fail_currencies_must_be_equal(a, b)
 
-  @spec to_string(t) :: String.t
+  @spec to_string(t, Keyword.t) :: String.t
   @doc ~S"""
   Converts a `Money` struct to a string representation
 

--- a/lib/money.ex
+++ b/lib/money.ex
@@ -227,10 +227,24 @@ defmodule Money do
   @doc ~S"""
   Converts a `Money` struct to a string representation
 
+  The following options are available
+
+    - `separator` - default `,`, sets the separator for groups of thousands.
+      "1,000"
+    - `delimeter` - default `.`, sets the decimal delimeter.
+      "1.23"
+    - `symbol` = default `true`, sets whether to display the currency symbol or not.
+
   ## Example:
 
       iex> Money.to_string(Money.new(123456, :GBP))
       "£1,234.56"
+      iex> Money.to_string(Money.new(123456, :EUR), separator: ".", delimeter: ",")
+      "€1.234,56"
+      iex> Money.to_string(Money.new(123456, :EUR), symbol: false)
+      "1,234.56"
+      iex> Money.to_string(Money.new(123456, :EUR), symbol: false, separator: "")
+      "1234.56"
 
   It can also be interpolated (It implements the String.Chars protocol)
 
@@ -239,11 +253,14 @@ defmodule Money do
       iex> "Total: #{Money.new(100_00, :USD)}"
       "Total: $100.00"
   """
-  def to_string(%Money{} = m) do
-    symbol = Currency.symbol(m)
-    super_unit = div(m.amount, 100) |> Integer.to_string |> reverse_group(3) |> Enum.join(",")
+  def to_string(%Money{} = m, opts \\ []) do
+    separator = Keyword.get(opts, :separator, ",")
+    delimeter = Keyword.get(opts, :delimeter, ".")
+    symbol = if Keyword.get(opts, :symbol, true), do: Currency.symbol(m), else: ""
+
+    super_unit = div(m.amount, 100) |> Integer.to_string |> reverse_group(3) |> Enum.join(separator)
     sub_unit = rem(abs(m.amount), 100) |> Integer.to_string |> String.rjust(2, ?0)
-    number = [super_unit, sub_unit] |> Enum.join(".")
+    number = [super_unit, sub_unit] |> Enum.join(delimeter)
     [symbol, number] |> Enum.join |> String.lstrip
   end
 

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -127,6 +127,21 @@ defmodule MoneyTest do
     assert Money.to_string(zar(1234567890)) == "R12,345,678.90"
   end
 
+  test "to_string configuration defaults" do
+    try do
+      Application.put_env(:money, :separator, ".")
+      Application.put_env(:money, :delimeter, ",")
+      Application.put_env(:money, :symbol, false)
+
+      assert Money.to_string(zar(1234567890)) == "12.345.678,90"
+      assert Money.to_string(zar(1234567890), separator: "|", delimeter: "§", symbol: true) == "R12|345|678§90"
+    after
+      Application.delete_env(:money, :separator)
+      Application.delete_env(:money, :delimeter)
+      Application.delete_env(:money, :symbol)
+    end
+  end
+
   test "to_string protocol" do
     m = usd(500)
     assert to_string(m) == Money.to_string(m)


### PR DESCRIPTION
Options can be set directly in the call to `Money.to_string` or as configuration defaults.
Implements #11 