### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Money 
 [![Build Status](https://travis-ci.org/liuggio/money.svg)](https://travis-ci.org/liuggio/money)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/liuggio/money.svg)](https://beta.hexfaktor.org/github/liuggio/money)
 
 Elixir library for working with Money safer, easier, and fun,
 is an interpretation of the Fowler's Money pattern in fun.prog.


### PR DESCRIPTION
Hi Giulio,

I saw that you're using [Credo](http://credo-ci.org) and wanted to take the opportunity to pitch my latest project for the Elixir community to you.

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/liuggio/money.svg)](https://beta.hexfaktor.org/github/liuggio/money)

This badge shows you an analysis for your dependencies. Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released. Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea!
