### PR TITLE
Add support for Money.cast/1 for existing Money struct

### DIFF
--- a/lib/money/ecto_type.ex
+++ b/lib/money/ecto_type.ex
@@ -34,6 +34,7 @@ if Code.ensure_compiled?(Ecto.Type) do
       Money.parse(str)
     end
     def cast(int) when is_integer(int), do: {:ok, Money.new(int)}
+    def cast(%Money{}=money), do: {:ok, money}
     def cast(_), do: :error
 
     @spec load(integer) :: {:ok, Money.t}

--- a/test/money/ecto_type_test.exs
+++ b/test/money/ecto_type_test.exs
@@ -33,6 +33,10 @@ if Code.ensure_compiled?(Ecto.Type) do
       assert Type.cast(1000) == {:ok, Money.new(1000, :GBP)}
     end
 
+    test "cast/1 Money" do
+      assert Type.cast(Money.new(1000)) == {:ok, Money.new(1000, :GBP)}
+    end
+
     test "cast/1 other" do
       assert Type.cast([]) == :error
     end


### PR DESCRIPTION
If you place a Money struct in an Ecto changeset, it fails.
This allows you to send a Money struct directly into a changeset.
```elixir
amount = Money.new(10000)
MyModel.changeset(%MyModel{}, %{amount: amount})
|> Repo.insert!
```