### PR TITLE
Add missing backticks to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ iex> amount = Money.new(1_234_50)
 %Money{amount: 123450, currency: :EUR}
 iex> Money.to_string(amount, symbol: true, symbol_on_right: true, symbol_space: true)
 "1.234,50 €"
+```
 
 ## LICENSE
 


### PR DESCRIPTION
Howdy!

Noticed a small "typo" in the readme that causes syntax highlighting to get a little off.