### PR TITLE
Allow users to customize showing the remainder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Money.Currency.name(Money.new(500, :AFN))     # Afghani
 Money.to_string(Money.new(500, :CNY))         # ¥ 5.00
 Money.to_string(Money.new(1_234_56, :EUR), separator: ".", delimeter: ",", symbol: false)
 "1.234,56"
+Money.to_string(Money.new(1_234_56, :USD), fractional_unit: false)  # "$1,234"
 ```
 
 ### Money.Sigils

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -173,6 +173,13 @@ defmodule MoneyTest do
     assert Money.to_string(zar(-1234567890)) == "R-12,345,678.90"
   end
 
+  test "to_string with fractional_unit false" do
+    assert Money.to_string(usd(500), fractional_unit: false) == "$5"
+    assert Money.to_string(eur(1234), fractional_unit: false) == "€12"
+    assert Money.to_string(nad(20305), fractional_unit: false) == "203"
+    assert Money.to_string(zar(1234567890), fractional_unit: false) == "R12,345,678"
+  end
+
   test "to_string configuration defaults" do
     try do
       Application.put_env(:money, :separator, ".")


### PR DESCRIPTION
This adds an option for `show_remainder` that defaults to `false`. If `true`, it
will not display the remaining portion after the delimiter.

I wasn't sure if I should call this remainder or `sub_currency` which is the only universal term I could find.