### PR TITLE
Allow sigils to handle underscores

### DIFF
--- a/lib/money/sigils.ex
+++ b/lib/money/sigils.ex
@@ -14,7 +14,13 @@ defmodule Money.Sigils do
       #> %Money{amount: 1000, currency: :USD}
   """
   def sigil_M(amount, []),
-    do: Money.new(String.to_integer(amount))
+    do: Money.new(to_integer(amount))
   def sigil_M(amount, [_,_,_]=currency),
-    do: Money.new(String.to_integer(amount), List.to_existing_atom(currency))
+    do: Money.new(to_integer(amount), List.to_existing_atom(currency))
+
+  defp to_integer(string) do
+    string
+    |> String.replace("_", "")
+    |> String.to_integer
+  end
 end

--- a/test/money/sigils_test.exs
+++ b/test/money/sigils_test.exs
@@ -16,6 +16,11 @@ defmodule Money.SigilsTest do
     assert ~M[1000] == Money.new(1000, :GBP)
   end
 
+  test "it can handle underscores like normal integers" do
+    assert ~M[1_000] == Money.new(1000, :GBP)
+    assert ~M[1_000_00] == Money.new(100000, :GBP)
+  end
+
   test "it can create a money object from a sigil with a currency" do
     assert ~M[1000]USD == Money.new(1000, :USD)
     assert ~M[1000]GBP == Money.new(1000, :GBP)


### PR DESCRIPTION
Sigils are given as strings, even when they are representing numbers.
This allows users to use an underscore as seperator, like they would normally
when working with a number in Elixir.