### PR TITLE
Allow casting a Map of ecto's embeds_many

### DIFF
--- a/lib/money/ecto_type.ex
+++ b/lib/money/ecto_type.ex
@@ -35,6 +35,9 @@ if Code.ensure_compiled?(Ecto.Type) do
     end
     def cast(int) when is_integer(int), do: {:ok, Money.new(int)}
     def cast(%Money{}=money), do: {:ok, money}
+    def cast(%{"amount"=>amount,"currency"=>currency}),
+      do: {:ok, Money.new(amount, currency)}
+    def cast(%{"amount"=>amount}), do: {:ok, Money.new(amount)}
     def cast(_), do: :error
 
     @spec load(integer) :: {:ok, Money.t}

--- a/test/money/ecto_type_test.exs
+++ b/test/money/ecto_type_test.exs
@@ -37,6 +37,11 @@ if Code.ensure_compiled?(Ecto.Type) do
       assert Type.cast(Money.new(1000)) == {:ok, Money.new(1000, :GBP)}
     end
 
+    test "cast/1 Map" do
+      assert Type.cast(%{"amount"=>1000,"currency"=>"EUR"}) == {:ok, Money.new(1000, :EUR)}
+      assert Type.cast(%{"amount"=>1000}) == {:ok, Money.new(1000, :GBP)}
+    end
+
     test "cast/1 other" do
       assert Type.cast([]) == :error
     end


### PR DESCRIPTION
### Migration

```elixir
defmodule Example.Repo.Migrations.AddCarts do
  use Ecto.Migration

  def change do
    create table(:carts) do
      add :products, :map
    end  
  end
end
```

### Schemas

```elixir
defmodule Cart do
  use Ecto.Schema

  schema "cart" do
    embeds_many :products, Product
  end
end

defmodule Product do
  use Ecto.Schema

  schema "product" do
    field :price, Money.Ecto.Type
  end
end
```

### Case

```elixir
Money.Ecto.Type.cast(%{"amount" => 324, "currency" => "EUR"})
```

A map without the currency is also supported. It requires a configured `default_currency`.

```elixir
Money.Ecto.Type.cast(%{"amount" => 324})
```

### Current behavior

```
** (ArgumentError) cannot load `%{"amount" => 324, "currency" => "EUR"}`
  as type Money.Ecto.Type for :price in schema Product
```

### New behavior

```elixir
{:ok, %Money{amount: 1000, currency: :EUR}}
```