### PR TITLE
Adding a HexDoc link to the readme for faster linking to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 Elixir library for working with Money safer, easier, and fun,
 is an interpretation of the Fowler's Money pattern in fun.prog.
 
+Documentation can be found at [https://hexdocs.pm/money/Money.html](https://hexdocs.pm/money/Money.html) on [HexDocs](https://hexdocs.pm)
+
 > "If I had a dime for every time I've seen someone use FLOAT to store currency, I'd have $999.997634" -- [Bill Karwin](https://twitter.com/billkarwin/status/347561901460447232)
 
 In short: You shouldn't represent monetary values by a float. Wherever

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 Elixir library for working with Money safer, easier, and fun,
 is an interpretation of the Fowler's Money pattern in fun.prog.
 
-Documentation can be found at [https://hexdocs.pm/money/Money.html](https://hexdocs.pm/money/Money.html) on [HexDocs](https://hexdocs.pm)
-
 > "If I had a dime for every time I've seen someone use FLOAT to store currency, I'd have $999.997634" -- [Bill Karwin](https://twitter.com/billkarwin/status/347561901460447232)
 
 In short: You shouldn't represent monetary values by a float. Wherever
 you need to represent money, use `Money`.
+
+Documentation can be found at [https://hexdocs.pm/money/Money.html](https://hexdocs.pm/money/Money.html) on [HexDocs](https://hexdocs.pm)
 
 ## USAGE
 


### PR DESCRIPTION
Just a matter of convenience. I find myself going to the github repo, then to hex package [https://hex.pm/packages/money/](https://hex.pm/packages/money/), then to the hexdocs link. 