### PR TITLE
Dividing negative one

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -373,16 +373,20 @@ defmodule Money do
 
   defp do_divide(_currency, _value, _rem, 0, acc), do: acc |> Enum.reverse
   defp do_divide(currency, value, 0, count, acc) do
+    acc   = [new(next_amount(value, 0, count), currency) | acc]
     count = decrement_abs(count)
-    acc   = [new(value, currency) | acc]
     do_divide(currency, value, 0, count, acc)
   end
   defp do_divide(currency, value, rem, count, acc) do
+    acc   = [new(next_amount(value, rem, count), currency) | acc]
     rem   = decrement_abs(rem)
     count = decrement_abs(count)
-    acc   = [new(increment_abs(value), currency) | acc]
     do_divide(currency, value, rem, count, acc)
   end
+
+  defp next_amount(0, -1, count) when count > 0, do: -1
+  defp next_amount(value, 0, _count), do: value
+  defp next_amount(value, _rem, _count), do: increment_abs(value)
 
   defp increment_abs(n) when n >= 0, do: n + 1
   defp increment_abs(n) when n < 0, do: n - 1

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -195,6 +195,10 @@ defmodule MoneyTest do
       usd(3)
     ]
 
+    assert Money.divide(Money.new(-1, :USD), 2) == [
+      usd(-1),
+      usd(0)
+    ]
   end
 
   test "test to_string" do

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -199,6 +199,11 @@ defmodule MoneyTest do
       usd(-1),
       usd(0)
     ]
+
+    assert Money.divide(Money.new(-1, :USD), -2) == [
+      usd(1),
+      usd(0)
+    ]
   end
 
   test "test to_string" do


### PR DESCRIPTION
Hi there @liuggio. First of all wanted to say thanks so much for your work on this excellent library.

We've been tracking down some really small discrepancies in spreadsheets and narrowed it down to the `&Money.divide/2` function. The behavior we are seeing is:
```
iex(2)> Money.new(-1, :USD) |> Money.divide(2)
[%Money{amount: 1, currency: :USD}, %Money{amount: 0, currency: :USD}]
```
We expected this to return  a list like:
```
[%Money{amount: -1, currency: :USD}, %Money{amount: 0, currency: :USD}]
```
I think there is a cornercase with the absolute value incrementing. I've gone ahead and added a new test and some helper functions. Let me know what you think.
